### PR TITLE
Proper error message for empty config

### DIFF
--- a/lib/paypal-sdk/core/config.rb
+++ b/lib/paypal-sdk/core/config.rb
@@ -241,7 +241,7 @@ module PayPal::SDK::Core
       def read_configurations(file_name = "config/paypal.yml")
         erb = ERB.new(File.read(file_name))
         erb.filename = file_name
-        YAML.load(erb.result)
+        YAML.load(erb.result) || {}
       end
 
     end


### PR DESCRIPTION
If `config/paypal.yml` is empty then `YAML.load` will return `false` on empty string.
Actual error in this case: `NoMethodError: undefined method '[]' for false:FalseClass`

By returning empty hash instead of `false` value from `read_configurations` method we're getting such error message:
`Paypal::SDK::Core::Exceptions::MissingConfig: Configuration[development] NotFound`